### PR TITLE
Fix nimble packaging to also produces binary.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ Use [nimble](https://github.com/nim-lang/nimble) to install `capnp.nim`:
 nimble install capnp
 ```
 
+Creates symlink to `canpnc` binary result. Capnp compiler expect `capnpc-nim` binary
+but nimble unable to produce binary name that contains `-`.
+
+```
+ln -s ~/.nimble/bin/capnpc ~/.nimble/bin/capnpc-nim
+```
+
 ## Generating wrapping code
 
 capnp.nim can generate Nim types (with some metadata) from `.capnp` file. The resulting objects use native Nim datatypes like seq or strings (this means that this implementation, unlike C++ one, doesn't have O(1) deserialization time). 

--- a/capnp.nimble
+++ b/capnp.nimble
@@ -4,6 +4,7 @@ version       = "0.0.1"
 author        = "Michał Zieliński <michal@zielinscy.org.pl>"
 description   = "Cap'n Proto bindings"
 license       = "MIT"
+bin           = "capnp/capnpc"
 
 [Deps]
 Requires: "nim >= 0.12.0"

--- a/capnp/capnpc.nim
+++ b/capnp/capnpc.nim
@@ -1,0 +1,7 @@
+import capnp/unpack, capnp/schema, capnp/compiler
+
+when isMainModule:
+  let data = readAll(stdin)
+  let req = newUnpacker(data).unpackStruct(0, CodeGeneratorRequest)
+
+  generateCode(req)

--- a/capnp/compiler.nim
+++ b/capnp/compiler.nim
@@ -234,7 +234,7 @@ proc generateType(self: Generator, id: uint64) =
   elif node.kind == NodeKind.`enum`:
     self.generateEnum(name, node)
 
-proc generateCode(req: CodeGeneratorRequest) =
+proc generateCode*(req: CodeGeneratorRequest) =
   let self = new(Generator)
   self.nodes = initTable[uint64, Node]()
   self.typeNames = initTable[uint64, string]()


### PR DESCRIPTION
Fix #1 

The resulted binary is `capnpc` instead of `capnpc-nim` because of nimble's limitation. CMIIW.

So, the user needs to create `capnpc-nim` symlink that points to `capnpc` binary.